### PR TITLE
[FIX] 管理者レシピ詳細画面表示のバグを修正

### DIFF
--- a/app/views/admin/post_recipes/show.html.erb
+++ b/app/views/admin/post_recipes/show.html.erb
@@ -1,6 +1,6 @@
 <!---------- 管理者側：レシピ詳細 -------------->
 <div class="container">
-  <%= render partial: 'shared/recipe_show', locals: { post_recipe: @post_recipe } %>
+  <%= render partial: 'shared/recipe_show', locals: { post_recipe: @post_recipe} %>
 
   <div class="row">
     <div class="mb-5 mx-auto">

--- a/app/views/public/post_recipes/show.html.erb
+++ b/app/views/public/post_recipes/show.html.erb
@@ -1,6 +1,20 @@
 <!---------- 顧客側：レシピ詳細 -------------->
 <div class="container mb-5">
-  <%= render partial: '/shared/recipe_show', locals: { post_recipe: @post_recipe, comment: @comment } %>
+  <%= render partial: '/shared/recipe_show', locals: { post_recipe: @post_recipe } %>
+
+<!--コメント投稿フォーム-->
+  <%= form_with model:[@post_recipe, @comment], remote: true do |f| %>
+  <div class="row mt-3">
+    <div class="form-group mb-1 mx-auto">
+      <%= f.text_area :comment, size:'60x4', placeholder:"コメントを入力", class: 'p-3 comment-content' %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="form-group offset-md-8">
+      <%= f.submit "送信", class:'btn btn-sm btn-outline-secondary'%>
+    </div>
+  </div>
+  <% end %>
 
   <div class="row mt-4">
     <div class="mx-auto">

--- a/app/views/shared/_recipe_show.html.erb
+++ b/app/views/shared/_recipe_show.html.erb
@@ -66,21 +66,8 @@
 <div class="row mt-5">
   <div class="col-md-8 offset-md-2">
     <h5 class="mb-0 ml-5 jp-font font-weight-bold">コメント</h5>
-    <%= render partial: '/shared/comments', locals: { post_recipe: post_recipe, comment: comment } %>
+    <%= render partial: '/shared/comments', locals: { post_recipe: post_recipe } %>
   </div>
 </div>
 
 
-  <!--コメント投稿フォーム-->
-<%= form_with model:[post_recipe, comment], remote: true do |f| %>
-<div class="row mt-3">
-  <div class="form-group mb-1 mx-auto">
-    <%= f.text_area :comment, size:'60x4', placeholder:"コメントを入力", class: 'p-3 comment-content' %>
-  </div>
-</div>
-<div class="row">
-  <div class="form-group offset-md-8">
-    <%= f.submit "送信", class:'btn btn-sm btn-outline-secondary'%>
-  </div>
-</div>
-<% end %>


### PR DESCRIPTION
- コメント投稿フォームは管理者側のレシピ詳細に不要のため、部分テンプレから顧客側の側の投稿フォームに移行
